### PR TITLE
Give some additional clarity to the failed route logic.

### DIFF
--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -55,8 +55,11 @@ class AuraRouter implements MiddlewareInterface
                     return Factory::createResponse(405)->withHeader('Allow', implode(', ', $failedRoute->allows)); // 405 METHOD NOT ALLOWED
                 case 'Aura\Router\Rule\Accepts':
                     return Factory::createResponse(406); // 406 NOT ACCEPTABLE
-                default:
+                case 'Aura\Router\Rule\Host':
+                case 'Aura\Router\Rule\Path':
                     return Factory::createResponse(404); // 404 NOT FOUND
+                default:
+                    return Factory::createResponse(500); // 500 INTERNAL SERVER ERROR
             }
         }
 


### PR DESCRIPTION
The changes here use [Radar.Adr](https://github.com/radarphp/Radar.Adr/blob/1.x/src/Responder/RoutingFailedResponder.php#L84)'s failed route handling for reference.