### PR TITLE
Depend on Matcher not Container

### DIFF
--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Middlewares;
 
-use Aura\Router\RouterContainer;
+use Aura\Router\Matcher;
 use Middlewares\Utils\Traits\HasResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -15,9 +15,9 @@ class AuraRouter implements MiddlewareInterface
     use HasResponseFactory;
 
     /**
-     * @var RouterContainer The router container
+     * @var Matcher The route matcher
      */
-    private $router;
+    private $matcher;
 
     /**
      * @var string Attribute name for handler reference
@@ -25,11 +25,11 @@ class AuraRouter implements MiddlewareInterface
     private $attribute = 'request-handler';
 
     /**
-     * Set the RouterContainer instance.
+     * Set the route matcher instance.
      */
-    public function __construct(RouterContainer $router)
+    public function __construct(Matcher $matcher)
     {
-        $this->router = $router;
+        $this->matcher = $matcher;
     }
 
     /**
@@ -46,11 +46,10 @@ class AuraRouter implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $matcher = $this->router->getMatcher();
-        $route = $matcher->match($request);
+        $route = $this->matcher->match($request);
 
         if (!$route) {
-            $failedRoute = $matcher->getFailedRoute();
+            $failedRoute = $this->matcher->getFailedRoute();
 
             switch ($failedRoute->failedRule) {
                 case 'Aura\Router\Rule\Allows':

--- a/tests/AuraRouterTest.php
+++ b/tests/AuraRouterTest.php
@@ -17,12 +17,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users', 'listUsers');
 
         $response = Dispatcher::run(
             [
-                new AuraRouter($router),
+                new AuraRouter($matcher),
             ],
             Factory::createServerRequest('GET', '/posts')
         );
@@ -34,12 +35,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users', 'listUsers');
 
         $response = Dispatcher::run(
             [
-                (new AuraRouter($router))->responseFactory(new GuzzleFactory()),
+                (new AuraRouter($matcher))->responseFactory(new GuzzleFactory()),
             ],
             Factory::createServerRequest('GET', '/posts')
         );
@@ -52,12 +54,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users', 'listUsers')->allows(['POST']);
 
         $response = Dispatcher::run(
             [
-                new AuraRouter($router),
+                new AuraRouter($matcher),
             ],
             Factory::createServerRequest('DELETE', '/users')
         );
@@ -70,12 +73,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users', 'listUsers')->accepts(['application/json']);
 
         $response = Dispatcher::run(
             [
-                new AuraRouter($router),
+                new AuraRouter($matcher),
             ],
             Factory::createServerRequest('GET', '/users')->withHeader('Accept', 'text/html')
         );
@@ -87,12 +91,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users', 'listUsers');
 
         $response = Dispatcher::run(
             [
-                new AuraRouter($router),
+                new AuraRouter($matcher),
                 function ($request) {
                     echo $request->getAttribute('request-handler');
                 },
@@ -107,12 +112,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users', 'listUsers');
 
         $response = Dispatcher::run(
             [
-                (new AuraRouter($router))->attribute('handler'),
+                (new AuraRouter($matcher))->attribute('handler'),
                 function ($request) {
                     echo $request->getAttribute('handler');
                 },
@@ -127,12 +133,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $matcher = $router->getMatcher();
 
         $map->get('list', '/users/{name}', 'getUser');
 
         $response = Dispatcher::run(
             [
-                new AuraRouter($router),
+                new AuraRouter($matcher),
                 function ($request) {
                     echo $request->getAttribute('name');
                 },


### PR DESCRIPTION
Is there a reson to inject the entire `RouterContainer`, rather than just the `Matcher` ?