### PR TITLE
Separate routing failed logic

### DIFF
--- a/src/AuraRouter/FailResponder.php
+++ b/src/AuraRouter/FailResponder.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+namespace Middlewares\AuraRouter;
+
+use Aura\Router\Route;
+use Aura\Router\Rule;
+use Middlewares\Utils\Traits\HasResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+
+class FailResponder implements FailResponderInterface
+{
+    use HasResponseFactory;
+
+    /**
+     * Respond to a failed route
+     */
+    public function respond(Route $route): ResponseInterface
+    {
+        switch ($route->failedRule) {
+            case Rule\Allows::class:
+                return $this->createResponse(405)
+                    ->withHeader('Allow', implode(', ', $route->allows)); // 405 METHOD NOT ALLOWED
+
+            case Rule\Accepts::class:
+                return $this->createResponse(406); // 406 NOT ACCEPTABLE
+
+            case Rule\Host::class:
+            case Rule\Path::class:
+                return $this->createResponse(404); // 404 NOT FOUND
+            default:
+                return $this->createResponse(500); // 500 INTERNAL SERVER ERROR
+        }
+    }
+}

--- a/src/AuraRouter/FailResponderInterface.php
+++ b/src/AuraRouter/FailResponderInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types = 1);
+
+namespace Middlewares\AuraRouter;
+
+use Aura\Router\Route;
+use Psr\Http\Message\ResponseInterface;
+
+interface FailResponderInterface
+{
+    public function respond(Route $route): ResponseInterface;
+}

--- a/tests/AuraRouterTest.php
+++ b/tests/AuraRouterTest.php
@@ -6,6 +6,7 @@ namespace Middlewares\Tests;
 use Aura\Router\RouterContainer;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Middlewares\AuraRouter;
+use Middlewares\AuraRouter\FailResponder;
 use Middlewares\Utils\Dispatcher;
 use Middlewares\Utils\Factory;
 use Middlewares\Utils\Factory\GuzzleFactory;
@@ -34,12 +35,13 @@ class AuraRouterTest extends TestCase
     {
         $router = new RouterContainer();
         $map = $router->getMap();
+        $fail = (new FailResponder())->responseFactory(new GuzzleFactory());
 
         $map->get('list', '/users', 'listUsers');
 
         $response = Dispatcher::run(
             [
-                (new AuraRouter($router))->responseFactory(new GuzzleFactory()),
+                (new AuraRouter($router, $fail)),
             ],
             Factory::createServerRequest('GET', '/posts')
         );


### PR DESCRIPTION
I think separating the "routing failed logic" would make it easier to extend the
logic, for example when using custom `Rules`.
