### PR TITLE
Add Route as Request Attribute (original PR: #3)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text=auto eol=lf
 
+/.github             export-ignore
 /tests               export-ignore
 .editorconfig        export-ignore
 .gitattributes       export-ignore

--- a/.phpstan.neon.dist
+++ b/.phpstan.neon.dist
@@ -1,5 +1,0 @@
-parameters:
-	level: 6
-	paths:
-		- src
-		- tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ public function process(
     ServerRequestInterface $request,
     RequestHandlerInterface $handler
 ): ResponseInterface {
-    // the resolve Route instance
+    /** @var Route $actualRoute The resolved Route instance */
     $route = $request->getAttribute('route');
+    
+    // this can also be used to get the handler reference
+    $route->handler;
 
     // "value"
     $route->extras['key'];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] - 2025-05-31
+### Added
+- Support for new `route($name)` option which sets the attribute name that will hold the resolved Route instance.
+
+This allows doing things like this when defining the route:
+
+```php
+$map->get('activities.get', '/activities', ListActivities::class)
+    ->extras([
+        'key' => 'value'
+     ]);
+```
+
+And then retrieve them inside the request:
+
+```php
+public function process(
+    ServerRequestInterface $request,
+    RequestHandlerInterface $handler
+): ResponseInterface {
+    // the resolve Route instance
+    $route = $request->getAttribute('route');
+
+    // "value"
+    $route->extras['key'];
+    
+    // "activities.get"
+    $route->name;
+}
+```
+
+### Changed
+- `attribute($name)` was used to set Request Handler's attribute name and the general feeling that it transmitted didn't fit anymore as there is now the `route()` method. So it was moved to a more specific `handler($name)` method.
+- The `attribute()` method is still there but marked as `@deprecated`.
+
+
 ## [2.1.1] - 2025-03-21
 ### Fixed
-- Added an check for failedRoute when false. This should be rare.
+- Added a check for failedRoute when false. This should be rare.
 
 ## [2.1.0] - 2025-03-16
 ### Added
@@ -98,6 +134,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.1.0] - 2016-10-02
 First version
 
+[2.2.0]: https://github.com/middlewares/aura-router/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/middlewares/aura-router/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/middlewares/aura-router/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/middlewares/aura-router/compare/v2.0.0...v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for new `route($name)` option which sets the attribute name that will hold the resolved Route instance.
 
-This allows settings new parameters or retrieves the existing ones:
+This allows setting parameters, `extras()` in our case but it could be that we just extended the Route class:
 
 ```php
 $map->get('activities.get', '/activities', ListActivities::class)
@@ -17,7 +17,7 @@ $map->get('activities.get', '/activities', ListActivities::class)
      ]);
 ```
 
-And then retrieve them inside the request:
+And then we can access the Route instance like this:
 
 ```php
 public function process(
@@ -37,7 +37,9 @@ public function process(
 
 ### Changed
 - `attribute($name)` was used to set Request Handler's attribute name and the general feeling that it transmitted didn't fit anymore as there is now the `route()` method. So it was moved to a more specific `handler($name)` method.
-- The `attribute()` method is still there but marked as `@deprecated`.
+
+### Deprecated
+- The `attribute()` method is still there but marked as `@deprecated` so it will be removed in the next major release. Just use `handler()` instead.
 
 
 ## [2.1.1] - 2025-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.2.0] - 2025-05-31
 ### Added
-- Support for new `route($name)` option which sets the attribute name that will hold the resolved Route instance.
+- Support for new `routeAttribute($name)` option which sets the attribute name that will hold the resolved Route instance.
 
 This allows setting parameters, `extras()` in our case, but it could also be that we just extended the Route class and we added new method or anything else that we would like to recover inside the Request Handler:
 
@@ -36,10 +36,10 @@ public function process(
 ```
 
 ### Changed
-- `attribute($name)` was used to set Request Handler's attribute name and the general feeling that it transmitted didn't fit anymore as there is now the `route()` method. So it was moved to a more specific `handler($name)` method.
+- `attribute($name)` was used to set Request Handler's attribute name and the general feeling that it transmitted didn't fit anymore as there is now the `routeAttribute($name)` method. So it was moved to a more specific `handlerAttribute($name)` method.
 
 ### Deprecated
-- The `attribute()` method is still there but marked as `@deprecated` so it will be removed in the next major release. Just use `handler()` instead.
+- The `attribute($name)` method is still there but marked as `@deprecated` so it will be removed in the next major release. Just use `handlerAttribute($name)` instead.
 
 
 ## [2.1.1] - 2025-03-21
@@ -60,7 +60,7 @@ public function process(
 
 ### Removed
 - Support for PHP 7.0 and 7.1
-- The `responseFactory()` option. Use the second argument in the contructor.
+- The `responseFactory()` option. Use the second argument in the constructor.
 
 ## [1.1.0] - 2018-08-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for new `route($name)` option which sets the attribute name that will hold the resolved Route instance.
 
-This allows doing things like this when defining the route:
+This allows settings new parameters or retrieves the existing ones:
 
 ```php
 $map->get('activities.get', '/activities', ListActivities::class)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for new `route($name)` option which sets the attribute name that will hold the resolved Route instance.
 
-This allows setting parameters, `extras()` in our case but it could be that we just extended the Route class:
+This allows setting parameters, `extras()` in our case, but it could also be that we just extended the Route class and we added new method or anything else that we would like to recover inside the Request Handler:
 
 ```php
 $map->get('activities.get', '/activities', ListActivities::class)

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -29,7 +29,7 @@ class AuraRouter implements MiddlewareInterface
 
     /**
      * Attribute name for handler reference.
-     * This is used to get the handler of a resolved route using $request->getAttribute($handlerName)
+     * This is used to get the handler of the selected route using $request->getAttribute($handlerAttribute)
      *
      * @var string
      */
@@ -37,7 +37,7 @@ class AuraRouter implements MiddlewareInterface
 
     /**
      * Attribute name for route instance.
-     * This is used to get the route instance of the resolved using $request->getAttribute($routeName)
+     * This is used to get the selected route instance using $request->getAttribute($routeAttribute)
      *
      * @var string
      */

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -53,9 +53,9 @@ class AuraRouter implements MiddlewareInterface
     }
 
     /**
-     * Set the attribute name to store handler reference.
+     * (DEPRECATED) Set the attribute name to store handler reference..
      *
-     * @deprecated Use handler() instead
+     * @deprecated Use handlerAttribute() instead
      * @see handlerAttribute()
      */
     public function attribute(string $attribute): self

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -13,14 +13,35 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class AuraRouter implements MiddlewareInterface
 {
-    /** @var RouterContainer The router container */
-    private $router;
+    /**
+     * The router container.
+     *
+     * @var RouterContainer
+     */
+    protected $router;
 
-    /** @var string Attribute name for handler reference */
-    private $attribute = 'request-handler';
+    /**
+     * Response factory to customize the response.
+     *
+     * @var ResponseFactoryInterface
+     */
+    protected $responseFactory;
 
-    /** @var ResponseFactoryInterface */
-    private $responseFactory;
+    /**
+     * Attribute name for handler reference.
+     * This is used to get the handler of a resolved route using $request->getAttribute($handlerName)
+     *
+     * @var string
+     */
+    protected $handler = 'request-handler';
+
+    /**
+     * Attribute name for route instance.
+     * This is used to get the route insntance of the resolved using $request->getAttribute($routeName)
+     *
+     * @var string
+     */
+    protected $route = 'route';
 
     /**
      * Set the RouterContainer instance.
@@ -33,10 +54,33 @@ class AuraRouter implements MiddlewareInterface
 
     /**
      * Set the attribute name to store handler reference.
+     *
+     * @deprecated Use handler() instead
+     * @see handler()
      */
     public function attribute(string $attribute): self
     {
-        $this->attribute = $attribute;
+        $this->handler = $attribute;
+
+        return $this;
+    }
+
+    /**
+     * Set the attribute name to store handler reference.
+     */
+    public function handler(string $handler): self
+    {
+        $this->handler = $handler;
+
+        return $this;
+    }
+
+    /**
+     * Set the attribute name to store the route instance.
+     */
+    public function route(string $route): self
+    {
+        $this->route = $route;
 
         return $this;
     }
@@ -77,8 +121,9 @@ class AuraRouter implements MiddlewareInterface
             $request = $request->withAttribute($name, $value);
         }
 
-        $request = $request->withAttribute($this->attribute, $route->handler);
-
+        $request = $request->withAttribute($this->handler, $route->handler)
+            ->withAttribute($this->route, $route);
+        
         return $handler->handle($request);
     }
 }

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -37,7 +37,7 @@ class AuraRouter implements MiddlewareInterface
 
     /**
      * Attribute name for route instance.
-     * This is used to get the route insntance of the resolved using $request->getAttribute($routeName)
+     * This is used to get the route instance of the resolved using $request->getAttribute($routeName)
      *
      * @var string
      */
@@ -123,7 +123,7 @@ class AuraRouter implements MiddlewareInterface
 
         $request = $request->withAttribute($this->handler, $route->handler)
             ->withAttribute($this->route, $route);
-        
+
         return $handler->handle($request);
     }
 }

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -33,7 +33,7 @@ class AuraRouter implements MiddlewareInterface
      *
      * @var string
      */
-    protected $handler = 'request-handler';
+    protected $handlerAttribute = 'request-handler';
 
     /**
      * Attribute name for route instance.
@@ -41,7 +41,7 @@ class AuraRouter implements MiddlewareInterface
      *
      * @var string
      */
-    protected $route = 'route';
+    protected $routeAttribute = 'route';
 
     /**
      * Set the RouterContainer instance.
@@ -56,11 +56,11 @@ class AuraRouter implements MiddlewareInterface
      * Set the attribute name to store handler reference.
      *
      * @deprecated Use handler() instead
-     * @see handler()
+     * @see handlerAttribute()
      */
     public function attribute(string $attribute): self
     {
-        $this->handler = $attribute;
+        $this->handlerAttribute = $attribute;
 
         return $this;
     }
@@ -68,9 +68,9 @@ class AuraRouter implements MiddlewareInterface
     /**
      * Set the attribute name to store handler reference.
      */
-    public function handler(string $handler): self
+    public function handlerAttribute(string $handlerAttribute): self
     {
-        $this->handler = $handler;
+        $this->handlerAttribute = $handlerAttribute;
 
         return $this;
     }
@@ -78,9 +78,9 @@ class AuraRouter implements MiddlewareInterface
     /**
      * Set the attribute name to store the route instance.
      */
-    public function route(string $route): self
+    public function routeAttribute(string $routeAttribute): self
     {
-        $this->route = $route;
+        $this->routeAttribute = $routeAttribute;
 
         return $this;
     }
@@ -121,8 +121,8 @@ class AuraRouter implements MiddlewareInterface
             $request = $request->withAttribute($name, $value);
         }
 
-        $request = $request->withAttribute($this->handler, $route->handler)
-            ->withAttribute($this->route, $route);
+        $request = $request->withAttribute($this->handlerAttribute, $route->handler)
+            ->withAttribute($this->routeAttribute, $route);
 
         return $handler->handle($request);
     }

--- a/tests/AuraRouterTest.php
+++ b/tests/AuraRouterTest.php
@@ -84,26 +84,6 @@ class AuraRouterTest extends TestCase
         $this->assertEquals(406, $response->getStatusCode());
     }
 
-    public function testOK(): void
-    {
-        $router = new RouterContainer();
-        $map = $router->getMap();
-
-        $map->get('list', '/users', 'listUsers');
-
-        $response = Dispatcher::run(
-            [
-                new AuraRouter($router),
-                function ($request) {
-                    echo $request->getAttribute('request-handler');
-                },
-            ],
-            Factory::createServerRequest('GET', '/users')
-        );
-
-        $this->assertEquals('listUsers', (string) $response->getBody());
-    }
-
     public function testHandlerAttributeDefaults(): void
     {
         $router = new RouterContainer();
@@ -178,7 +158,6 @@ class AuraRouterTest extends TestCase
                     $actualRoute = $request->getAttribute('route');
 
                     Assert::assertEquals($expectedRoute, $actualRoute);
-                    ;
                 },
             ],
             Factory::createServerRequest('GET', '/users')
@@ -199,7 +178,6 @@ class AuraRouterTest extends TestCase
                     $actualRoute = $request->getAttribute('custom-route');
 
                     Assert::assertEquals($expectedRoute, $actualRoute);
-                    ;
                 },
             ],
             Factory::createServerRequest('GET', '/users')

--- a/tests/AuraRouterTest.php
+++ b/tests/AuraRouterTest.php
@@ -104,7 +104,7 @@ class AuraRouterTest extends TestCase
         $this->assertEquals('listUsers', (string) $response->getBody());
     }
 
-    public function testHandlerConfigDefaults(): void
+    public function testHandlerAttributeDefaults(): void
     {
         $router = new RouterContainer();
         $map = $router->getMap();
@@ -124,7 +124,7 @@ class AuraRouterTest extends TestCase
         $this->assertEquals('listUsers', (string) $response->getBody());
     }
 
-    public function testHandlerConfigIsCustomizable(): void
+    public function testHandlerAttributeIsCustomizable(): void
     {
         $router = new RouterContainer();
         $map = $router->getMap();
@@ -133,7 +133,7 @@ class AuraRouterTest extends TestCase
 
         $response = Dispatcher::run(
             [
-                (new AuraRouter($router))->handler('handler'),
+                (new AuraRouter($router))->handlerAttribute('handler'),
                 function ($request) {
                     echo $request->getAttribute('handler');
                 },
@@ -144,7 +144,7 @@ class AuraRouterTest extends TestCase
         $this->assertEquals('listUsers', (string) $response->getBody());
     }
 
-    public function testHandlerConfigWorksWithDeprecatedMethod(): void
+    public function testHandlerAttributeWorksWithDeprecatedMethod(): void
     {
         $router = new RouterContainer();
         $map = $router->getMap();
@@ -185,7 +185,7 @@ class AuraRouterTest extends TestCase
         );
     }
 
-    public function testRouteConfigIsCustomizable(): void
+    public function testRouteAttributeIsCustomizable(): void
     {
         $router = new RouterContainer();
         $map = $router->getMap();
@@ -194,7 +194,7 @@ class AuraRouterTest extends TestCase
 
         Dispatcher::run(
             [
-                (new AuraRouter($router))->route('custom-route'),
+                (new AuraRouter($router))->routeAttribute('custom-route'),
                 function ($request) use ($expectedRoute) {
                     $actualRoute = $request->getAttribute('custom-route');
 

--- a/tests/AuraRouterTest.php
+++ b/tests/AuraRouterTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Middlewares\Tests;
 
+use Aura\Router\Route;
 use Aura\Router\RouterContainer;
 use Middlewares\AuraRouter;
 use Middlewares\Utils\Dispatcher;
@@ -155,6 +156,7 @@ class AuraRouterTest extends TestCase
             [
                 new AuraRouter($router),
                 function ($request) use ($expectedRoute) {
+                    /** @var Route $actualRoute */
                     $actualRoute = $request->getAttribute('route');
 
                     Assert::assertEquals($expectedRoute, $actualRoute);
@@ -175,6 +177,7 @@ class AuraRouterTest extends TestCase
             [
                 (new AuraRouter($router))->routeAttribute('custom-route'),
                 function ($request) use ($expectedRoute) {
+                    /** @var Route $actualRoute */
                     $actualRoute = $request->getAttribute('custom-route');
 
                     Assert::assertEquals($expectedRoute, $actualRoute);


### PR DESCRIPTION
Hi,

I created a new PR, it was harder to update the old branch than to create a new one.

Main points:

- Changed class properties from Private to Protected: I feel like it's more aligned with open-source, and  I'm planning to do so in other middleware too, as I touch them.
- Added a new `handler()` method that does the same as the "old" `attribute()` which was marked as `@deprecated`
- Added `route()` method to set the route instance attribute name.